### PR TITLE
More robust lammps error checking

### DIFF
--- a/structopt/tools/lammps.py
+++ b/structopt/tools/lammps.py
@@ -241,8 +241,8 @@ class LAMMPS(object):
         self.output = output.decode('utf-8').split('\n')[:-1]
 
         # Check if the calculation completed without errors. If it does,
-        # we need to copy the files.
-        if 'ERROR' in self.output[-1]:
+        # we need to save the files self.calcdir.
+        if CALCULATION_END_MARK not in self.output[-1]:
             return True
 
         return False


### PR DESCRIPTION
Made the lammps error checking more robust. This was actually what the old lammps calculator used, and I just remembered. This should be better, in that that statement is ALWAYS printed if the calculation finishes without errors.
